### PR TITLE
Update CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,76 +1,274 @@
-# Contributor Covenant Code of Conduct
+### Overview
 
-## Our Pledge
+With the goal of supporting our fellow group members in doing the best
+science we can, we expect that all members of the Simulating eXtreme
+Spacetimes collaboration
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+-   Behave professionally in a way that is welcoming and respectful to
+    all participants.
 
-## Our Standards
+-   Behave in a way that is free from any form of discrimination,
+    harassment, or retaliation.
 
-Examples of behavior that contributes to creating a positive environment
-include:
+-   Treat each other with collegiality and respect and help to create a
+    supportive working environment.
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+For more specific guidelines for appropriate conduct, we refer
+collaboration members to the “Ground Rules” section below, which is
+based on the LLVM Code of Conduct at
+<https://llvm.org/docs/CodeOfConduct.html>.
 
-Examples of unacceptable behavior by participants include:
+If you observe violations of the code of conduct, or have concerns about
+potential violations, we encourage you to formally report this to one or
+more members of the SXS Executive Committee. After investigation, the
+Executive Committee will work to resolve the situation, in consultation
+with parties involved and preserving confidentiality to the extent
+allowed by law, as outlined below.
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
- advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
- address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
- professional setting
+If you have a concern about a code of conduct violation or potential
+violation, but you do not wish to report it formally, you can speak
+informally and confidentially about your concern with the SXS
+Ombudsperson (see below).
 
-## Our Responsibilities
+The Executive Committee will take appropriate action to ensure that all
+members of the collaboration meet the expectations of our code of
+conduct.
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+### Ombudsperson
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+The Ombudsperson (currently Geoffrey Lovelace, email
+*ombudsperson@black-holes.org*) is a senior member of the collaboration,
+either faculty or a senior researcher, who offers confidential, neutral,
+and informal conflict resolution services to members of the SXS
+Collaboration. All collaboration members should feel free to contact the
+Ombudsperson to informally and confidentially discuss any concerns that
+they might have regarding conflicts, problems, violations of the code of
+conduct, or any other concerns they might have.
 
-## Scope
+After speaking with Ombudsperson, if you wish, you can choose to ask the
+Ombudsperson to bring your concerns to the attention of the SXS
+Executive Committee or to other people at the appropriate institutions,
+and you can also choose to report your concerns formally to the SXS
+Executive Committee (as outlined below). Otherwise, unless there is a
+serious issue of safety, your conversations with the Ombudsperson will
+remain confidential.
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+We have adopted the same policy as the LIGO Scientific Collaboration
+Ombudsperson; see this document, replacing “LSC” with “SXS
+Collaboration”, and “LSC Spokesperson” with “the SXS Executive
+Committee”, for more details about the Ombudsperson’s role:
+<https://dcc.ligo.org/public/0099/M1300006/001/LSCOmbudsperson.pdf>
 
-## Enforcement
+The executive committee will solicit volunteers for the position. The
+executive committee will choose the ombudsperson by holding an election
+with ranked-choice voting among those nominees that agreed to stand for
+election. The ombudsperson serves a two-year term.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at support@github.com. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+### Student/Postdoc Advocate
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+The Student/Postdoc Advocate (currently Masha Okounkova, email
+*sxs-advocate@black-holes.org*) is someone who will advocate positively
+for the people in the collaboration with less power, specifically high
+school students, undergraduate students, summer REU students, grad
+students, and postdocs. It may sometimes be daunting to go to
+professors, so please feel free to talk to the Advocate about any issues
+and concerns you may have in the collaboration, especially concerns
+about culture and environment. The Advocate can bring up (anonymously)
+any of your concerns with the SXS executive committee if you wish.
+Otherwise, unless there’s a serious issue of safety, the Advocate will
+keep the Ombudsperson in the loop but otherwise keep your conversation
+confidential.
 
-## Attribution
+The SXS Advocate must be elected by the student and postdoc members of
+SXS, and be within two years of their Ph.D. (i.e. a senior graduate
+student or a new postdoc). The SXS executive committee will have a call
+for nominations and then consult with nominees to see if they are
+willing to be the advocate. If the SXS executive committee has any
+concerns with a nominee, they will discuss these concerns with the
+nominator. The SXS executive committee will then supervise an election
+among SXS student and postdoc members with ranked-choice voting among
+those nominees that agreed to stand for election. Once the list of
+candidates for SXS advocate is announced, the executive committee cannot
+change the candidate list (unless there is a serious violation of the
+SXS code of conduct). The Advocate is elected for a one-year term, and
+may be re-elected.
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+### Ground Rules (following the LLVM Code of Conduct)
 
-[homepage]: https://www.contributor-covenant.org
+The Simulating eXtreme Spacetimes (SXS) Collaboration has the goal of
+supporting our fellow group members in doing the best science we can. To
+this end, we have a few ground rules that we ask people to adhere to:
 
-For answers to common questions about this code of conduct, see
-https://www.contributor-covenant.org/faq
+-   be friendly and patient,
+
+-   be welcoming,
+
+-   be considerate,
+
+-   be respectful,
+
+-   be careful in the words that you choose and be kind to others, and
+
+-   when we disagree, try to understand why.
+
+This is not an exhaustive list of things that you can’t do. Rather, take
+it in the spirit in which it is intended — a guide to make it easier to
+communicate and participate in the community. This code of conduct
+applies to all spaces managed by the SXS Collaboration. This includes
+physical spaces at institutions with SXS group members; Slack channels,
+mailing lists, and bug trackers; SXS Collaboration events (such as the
+visiting institutions and workshops); and any other forums created by
+the collaboration uses for communication. It applies to all of your
+communication and conduct in these spaces, including emails, chats,
+things you say, slides, videos, posters, signs, or even t-shirts you
+display in these spaces. In addition, violations of this code outside
+these spaces may, in rare cases, affect a person’s ability to
+participate within them, when the conduct amounts to an egregious
+violation of this code. If you believe someone is violating the code of
+conduct, we ask that you report it by emailing one or more members of
+the SXS Executive Committee (see “Reporting” below). If you would rather
+not formally report your concern, you should feel free to discuss it
+informally and confidentially with the SXS Ombudsperson.
+
+-   **Be friendly and patient.** During teleconferences and meetings,
+    participants who wish to speak should feel free to type “hand up” or
+    similar in the comment box, as needed, to get the chairs’ attention.
+    Meeting/teleconference chairs are encouraged to make space for those
+    unfamiliar with the topic of discussion to ask questions and engage.
+
+-   **Be welcoming.** We strive to be a community that welcomes and
+    supports people of all backgrounds and identities. This includes,
+    but is not limited to members of any race, ethnicity, culture,
+    national origin, colour, immigration status, social and economic
+    class, educational level, sex, sexual orientation, gender identity
+    and expression, age, size, family status, political belief, religion
+    or lack thereof, and mental and physical ability.
+
+-   **Be considerate.** Your work will be used by other people, and you
+    in turn will depend on the work of others. Any decision you take
+    will affect users and colleagues, and you should take those
+    consequences into account. Remember that we’re a world-wide
+    community, so you might not be communicating in someone else’s
+    primary language.
+
+-   **Be respectful.** Not all of us will agree all the time, but
+    disagreement is no excuse for poor behavior and poor manners. We
+    might all experience some frustration now and then, but we cannot
+    allow that frustration to turn into a personal attack. It’s
+    important to remember that a community where people feel
+    uncomfortable or threatened is not a productive one. Members of the
+    SXS Collaboration should be respectful when dealing with other
+    members as well as with people outside the SXS Collaboration.
+
+-   **Be careful in the words that you choose and be kind to others.**
+    Do not insult or put down other participants. Harassment and other
+    exclusionary behavior aren’t acceptable. This includes, but is not
+    limited to:
+
+    -   Violent threats or language directed against another person.
+
+    -   Discriminatory jokes and language.
+
+    -   Posting sexually explicit or violent material.
+
+    -   Posting (or threatening to post) other people’s personally
+        identifying information (“doxing”).
+
+    -   Personal insults, especially those using racist or sexist terms.
+
+    -   Unwelcome sexual attention.
+
+    -   Advocating for, or encouraging, any of the above behavior.
+
+-   **In general, if someone asks you to stop, then stop.** Persisting
+    in such behavior after being asked to stop is considered harassment.
+
+-   **When we disagree, try to understand why.** Disagreements, both
+    social and technical, happen all the time, and SXS is no exception.
+    It is important that we resolve disagreements and differing views
+    constructively. Remember that we’re different. The strength of
+    communities comes from having a varied community, people from a wide
+    range of backgrounds. Different people have different perspectives
+    on issues. Being unable to understand why someone holds a viewpoint
+    doesn’t mean that they’re wrong. Don’t forget that it is human to
+    err and blaming each other doesn’t get us anywhere. Instead, focus
+    on helping to resolve issues and learning from mistakes.
+
+### Reporting (following the LLVM reporting process)
+
+If you believe someone is violating the code of conduct, you can always
+file a report by emailing one or more members of the SXS Executive
+Committee. **All reports will be kept confidential.**
+
+If you believe anyone is in **physical danger**, please notify
+appropriate law enforcement first. If you are unsure what law
+enforcement agency is appropriate, please include this in your report
+and we will attempt to notify them.
+
+Reports of violations of the code of conduct can be as formal or
+informal as needed for the situation at hand. If possible, please
+include as much information as you can. If you feel comfortable, please
+consider including:
+
+-   Your contact info (so we can get in touch with you if we need to
+    follow up).
+
+-   Names (real, nicknames, or pseudonyms) of any individuals involved.
+    If there were other witnesses besides you, please try to include
+    them as well.
+
+-   When and where the incident occurred. Please be as specific as
+    possible.
+
+-   Your account of what occurred. If there is a publicly available
+    record (e.g. a mailing list archive or Slack logs) please include a
+    link.
+
+-   Any extra context you believe existed for the incident.
+
+-   If you believe this incident is ongoing.
+
+-   Any other information you believe we should have.
+
+What happens after you file a report? (Following the LLVM process) — You
+will receive an email from the SXS Executive Committee member(s) you
+contacted, acknowledging receipt within 24 business hours (and we will
+aim to respond much quicker than that). If you do not receive an
+acknowledgment, please resend your report.
+
+They will review the incident and try to determine:
+
+-   What happened and who was involved.
+
+-   Whether this event constitutes a code of conduct violation.
+
+-   Whether this is an ongoing situation, or if there is a threat to
+    anyone’s physical safety.
+
+Once the contacted SXS Executive Committee members have a complete
+account of the events they will make a recommendation to the full
+Executive Committee as to how to respond. Responses may include:
+
+-   Nothing, if we determine no violation occurred or it has already
+    been appropriately resolved.
+
+-   Providing either moderation or mediation to ongoing interactions
+    (where appropriate, safe, and desired by both parties).
+
+-   A private reprimand from the working group to the individuals
+    involved.
+
+-   An imposed vacation (i.e. asking someone to take a week off from a
+    mailing list or Slack).
+
+-   Escalation to the appropriate institutions.
+
+-   Involvement of relevant law enforcement if appropriate.
+
+If the situation is not resolved within one week, we will respond within
+one week to the original reporter with an update and explanation. Once
+we have determined our response, we will separately contact the original
+reporter and other individuals to let them know what actions (if any)
+will be taken. We will take into account feedback from the individuals
+involved on the appropriateness of our response, but we don’t guarantee
+we’ll act on it.


### PR DESCRIPTION
Remove the template code of conduct, and replace with the SXS code of conduct. No new changes to the CoC were introduced, and all of the section formatting was kept as in the original document.